### PR TITLE
Fixed 404 error message

### DIFF
--- a/web-fonts.sass
+++ b/web-fonts.sass
@@ -6,8 +6,12 @@
  * but it still has not been merged, due to lack of minor comments.
  * That was five months ago.
 
-=web-font($fonts, $variants: (), $subsets: (), $text: "", $effects: ())
+=web-font($fonts, $variants: (), $subsets: (), $text: "", $effects: (), $secure: false)
+  //The $secure var defaults to false, the $url var is inited to use http
   $url: "http://fonts.googleapis.com/css?family="
+  //If flagged secure, import fonts using https
+  @if $secure
+    $url: "https://fonts.googleapis.com/css?family="
   $i: 0
   // Add the family argument to the URL string.
   // We can assume that the user will always specify at least one font.

--- a/web-fonts.scss
+++ b/web-fonts.scss
@@ -7,8 +7,16 @@
  * That was five months ago.
  */
 
-@mixin web-font($fonts, $variants: (), $subsets: (), $text: '', $effects: ()) {
+@mixin web-font($fonts, $variants: (), $subsets: (), $text: '', $effects: (), $secure: false) {
+
+  //The $secure var defaults to false, the $url var is inited to use http
   $url: "http://fonts.googleapis.com/css?family=";
+
+  //If flagged secure, import fonts using https
+  @if $secure {
+    $url: "https://fonts.googleapis.com/css?family=";
+  }
+
   $i: 0;
   
   // Add the family argument to the URL string.


### PR DESCRIPTION
Although all the fonts include correctly, using the url "//fonts.googleapis.com/..." resulted in either a failed GET request when running locally or a 404 status response error message in the console. I added "http:" to the beginning, and having the protocol at the beginning seems to have fixed the error message.
