### PR TITLE
Fix link to Google Web Fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Sass Web Fonts
 ==============
 
-A Sass mixin to allow easy, efficient usage of [Google Web Fonts](https://google.com/webfonts).
+A Sass mixin to allow easy, efficient usage of [Google Web Fonts](https://www.google.com/fonts).
 
 You can clone this repo and include [_web-fonts.scss](https://github.com/penman/Sass-Web-Fonts) in your project manually, or you can install the _sass-web-fonts_ package from [Bower](http://bower.io).
 


### PR DESCRIPTION
Link without www. prefix 404s, if www is added it 302s to https://www.google.com/fonts